### PR TITLE
Add SELECT permission for gtfs_rides_agg_by_hour

### DIFF
--- a/modules/openbus/stride_db_roles.tf
+++ b/modules/openbus/stride_db_roles.tf
@@ -17,6 +17,7 @@ GRANT SELECT ON TABLE public.gtfs_ride_stop TO __role_name__;
 GRANT SELECT ON TABLE public.gtfs_stop TO __role_name__;
 GRANT SELECT ON TABLE public.gtfs_route TO __role_name__;
 GRANT SELECT ON TABLE public.gtfs_stop_mot_id TO __role_name__;
+GRANT SELECT ON TABLE public.gtfs_rides_agg_by_hour TO __role_name__;
 GRANT SELECT ON TABLE public.siri_ride TO __role_name__;
 GRANT SELECT ON TABLE public.siri_ride_stop TO __role_name__;
 GRANT SELECT ON TABLE public.siri_route TO __role_name__;


### PR DESCRIPTION
Currently it is denied on the open-bus-stride-api production server.